### PR TITLE
Update image tag to nodeapp-7a37dd2

### DIFF
--- a/node-app/values.yaml
+++ b/node-app/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: quay.io/avadhut22/node-app
   pullPolicy: IfNotPresent
-  tag: 'nodeapp-c613745'
+  tag: "nodeapp-7a37dd2"
 
 imagePullSecrets:
   - name: avadhoot


### PR DESCRIPTION
This PR updates the Helm chart values.yaml with the new image tag `nodeapp-7a37dd2`.