### PR TITLE
Update image tag to nodeapp-2f6e2f6

### DIFF
--- a/node-app/values.yaml
+++ b/node-app/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: quay.io/avadhut22/node-app
   pullPolicy: IfNotPresent
-  tag: "nodeapp-a1bf1cc"
+  tag: "nodeapp-2f6e2f6"
 
 imagePullSecrets:
   - name: avadhoot


### PR DESCRIPTION
This PR updates the Helm chart values.yaml with the new image tag `nodeapp-2f6e2f6`.